### PR TITLE
Add fireAuthProviders

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Make sure you have Nuxt and Firebase installed in your project.
 
 ```json
 "dependencies": {
-  "nuxt": "^2.3.4",
-  "firebase": "^5.8.0"
+  "nuxt": "^2.6.2",
+  "firebase": "^5.10.0"
 }
 ```
 
@@ -83,6 +83,14 @@ Firebase products supported by nuxt-fire so far:
 | Messaging         | \$fireMess    |
 
 See [Firebase's official docs](https://firebase.google.com/docs/) for more usage information.
+
+You can further access the objects like so
+
+| Firebase Obj  | Shortcut      |
+| ------------- | ------------- |
+| firebase.auth | \$fireAuthObj |
+
+(only works for the auth object for now)
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-fire",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "description": "Intergrate Firebase into your Nuxt project.",
   "main": "index.js",
@@ -15,6 +15,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "firebase": "^5.8.0"
+    "firebase": "^5.10.0"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -37,7 +37,9 @@ export default (ctx, inject) => {
 
   if (options.useOnly.includes('auth')) {
     const fireAuth = firebase.auth()
+    const fireAuthProviders = firebase.auth
     inject('fireAuth', fireAuth)
+    inject('fireAuthProviders', fireAuthProviders)
   }
 
   // Firebase Messaging can only be initiated on client side

--- a/plugin.js
+++ b/plugin.js
@@ -37,9 +37,9 @@ export default (ctx, inject) => {
 
   if (options.useOnly.includes('auth')) {
     const fireAuth = firebase.auth()
-    const fireAuthProviders = firebase.auth
+    const fireAuthObj = firebase.auth
     inject('fireAuth', fireAuth)
-    inject('fireAuthProviders', fireAuthProviders)
+    inject('fireAuthObj', fireAuthObj)
   }
 
   // Firebase Messaging can only be initiated on client side


### PR DESCRIPTION
Add Providers which are missing within the instance of $fireAuth

Usage:
`loginWithGoogle() {
      var provider = new this.$fireAuthProviders.GoogleAuthProvider();
      this.$fireAuth.signInWithRedirect(provider);
    }`