### PR TITLE
Check if Firebase Messaging is supported.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -8,7 +8,7 @@ import firebase from 'firebase/app'
 <%= options.useOnly.includes('performance') ? "import 'firebase/performance'" : "" %>
 
 export default (ctx, inject) => {
-  
+
   const options = <%= serialize(options) %>
 
   // Don't include when Firebase is already initialized
@@ -52,7 +52,7 @@ export default (ctx, inject) => {
   }
 
   // Firebase Messaging can only be initiated on client side
-  if (process.browser && options.useOnly.includes('messaging')) {
+  if (process.browser && options.useOnly.includes('messaging') && firebase.messaging.isSupported()) {
     const fireMess = firebase.messaging()
     const fireMessObj = firebase.messaging
     inject('fireMess', fireMess)


### PR DESCRIPTION
This adds a check to ensure Firebase Messaging is supported in the current environment before instantiating it.  It fixes an issue with Safari throwing an Environment Not Supported exception which breaks app loading.

Adding this check allows our apps to actually load and work when using Safari. 

Closes #38 