### PR TITLE
fix firebase-messaging-sw.js path

### DIFF
--- a/packages/nuxt-fire/src/index.js
+++ b/packages/nuxt-fire/src/index.js
@@ -17,6 +17,7 @@ export default function nuxtFire(moduleOptions) {
     this.addTemplate({
       src: path.resolve(__dirname, 'templates/firebase-messaging-sw.js'),
       fileName: path.resolve(
+        this.options.srcDir,
         this.options.dir.static,
         'firebase-messaging-sw.js'
       ),


### PR DESCRIPTION

The path used on firebase-messaging-sw.js creation is not correct.

