### PR TITLE
fixed broken link to config section

### DIFF
--- a/packages/docs/guide/getting-started/README.md
+++ b/packages/docs/guide/getting-started/README.md
@@ -21,7 +21,7 @@ yarn add nuxt-fire # OR npm i nuxt-fire
 
 Add the below code to your **nuxt.config.js** modules array and adjust it according to your needs.
 
-Visit the [config section](/guide/config) for a detailed overview about each configuration.
+Visit the [config section](/guide/options/#config) for a detailed overview about each configuration.
 
 ### Simple Configuration
 


### PR DESCRIPTION
I was going through the docs and saw a broken link.

It now links to the config section of the options page.