### PR TITLE
feat: add runtime config support

### DIFF
--- a/packages/firebase-module/lib/module.js
+++ b/packages/firebase-module/lib/module.js
@@ -10,15 +10,19 @@ module.exports = function (moduleOptions) {
     injectModule: true,
   }
 
+  const publicRuntimeConfig = this.nuxt.options.publicRuntimeConfig
+  const runtimeConfig =
+    (publicRuntimeConfig && publicRuntimeConfig.firebase) || {}
+
   const options = Object.assign(
     defaultOptions,
     this.options.firebase,
     moduleOptions
   )
-  const currentEnv = getCurrentEnv(options)
-
+  options.config = Object.assign(options.config, runtimeConfig)
   validateOptions(options)
 
+  const currentEnv = getCurrentEnv(options)
   options.config = getFinalUseConfigObject(options.config, currentEnv)
   validateConfigKeys(options, currentEnv)
 

--- a/packages/firebase-module/lib/module.js
+++ b/packages/firebase-module/lib/module.js
@@ -1,3 +1,6 @@
+const { writeFile, readFile } = require('fs/promises')
+const renderTemplate = require('lodash/template')
+const serialize = require('serialize-javascript')
 const { resolve } = require('path')
 const firebase = require('firebase/compat/app')
 const logger = require('./utils/logger')
@@ -67,14 +70,14 @@ module.exports = function (moduleOptions) {
   }
 
   // Register main firebase-module plugin
-  this.addPlugin({
+  const mainPluginOptions = {
     src: r('plugins/main.js'),
     fileName: 'firebase/index.js',
-    options: {
-      ...options,
-      ...templateUtils,
-      enabledServices,
-    },
+    options: { ...options, ...templateUtils, enabledServices },
+  }
+  this.addPlugin(mainPluginOptions)
+  this.nuxt.hook('listen', () => {
+    addRuntimePlugin.call(this, mainPluginOptions)
   })
 
   // add ssrAuth plugin last
@@ -96,7 +99,7 @@ function addServiceWorker(
   templateOptions = {}
 ) {
   // Add Service Worker Template
-  this.addTemplate({
+  const serviceWorkerOptions = {
     src: r(`sw-templates/${templateFile}`),
     fileName: resolve(
       this.options.srcDir,
@@ -110,7 +113,31 @@ function addServiceWorker(
         process.env.NODE_ENV === 'production' ? onFirebaseHosting : false,
       ...templateOptions,
     },
+  }
+  this.addTemplate(serviceWorkerOptions)
+
+  this.nuxt.hook('listen', () => {
+    addRuntimeTemplate.call(this, serviceWorkerOptions)
   })
+}
+
+function addRuntimeFile({ src, fileName, options }) {
+  readFile(src, 'utf-8').then((template) => {
+    const compileTemplate = renderTemplate(template, { imports: { serialize } })
+
+    writeFile(
+      fileName,
+      compileTemplate({ options, globals: { nuxt: '$nuxt' } })
+    )
+  })
+}
+
+function addRuntimeTemplate({ src, fileName, options }) {
+  addRuntimeFile({ src, fileName, options })
+}
+
+function addRuntimePlugin({ src, fileName, options }) {
+  addRuntimeFile({ src, fileName: r(this.options.buildDir, fileName), options })
 }
 
 /**
@@ -182,7 +209,7 @@ function loadAuth(options) {
   if (ssrConfig.serverLogin && credential) {
     options.sessions = Object.assign({}, ssrConfig.serverLogin)
 
-    this.addPlugin({
+    const serverLoginPluginOptions = {
       src: r('plugins/services/auth.serverLogin.js'),
       fileName: 'firebase/service.auth.serverLogin-server.js',
       mode: 'server',
@@ -190,6 +217,10 @@ function loadAuth(options) {
         credential,
         config: options.config,
       },
+    }
+    this.addPlugin(serverLoginPluginOptions)
+    this.nuxt.hook('listen', () => {
+      addRuntimePlugin.call(this, serverLoginPluginOptions)
     })
 
     const sessionLifetime = options.sessions.sessionLifetime || 0
@@ -218,16 +249,22 @@ function loadAuth(options) {
     })
   }
 
+  const pluginOptions = {
+    src: r('plugins/services/auth.ssr.js'),
+    fileName: 'firebase/service.auth.ssr-server.js',
+    mode: 'server',
+    options: {
+      credential,
+      config: options.config,
+    },
+  }
+
+  this.nuxt.hook('listen', () => {
+    addRuntimePlugin.call(this, pluginOptions)
+  })
+
   return () => {
-    this.addPlugin({
-      src: r('plugins/services/auth.ssr.js'),
-      fileName: 'firebase/service.auth.ssr-server.js',
-      mode: 'server',
-      options: {
-        credential,
-        config: options.config,
-      },
-    })
+    this.addPlugin(pluginOptions)
   }
 }
 

--- a/packages/firebase-module/lib/plugins/main.js
+++ b/packages/firebase-module/lib/plugins/main.js
@@ -11,7 +11,9 @@ for (const service of enabledServices) { %>
 const appConfig = <%= serialize(options.config) %>
 
 export default async (ctx, inject) => {
-
+  const runtimeConfig = ctx.$config && ctx.$config.firebase || {}
+  Object.assign(appConfig, runtimeConfig)
+  
   <%/****************************************
   **************** LAZY MODE **************
   ****************************************/%>

--- a/packages/firebase-module/package.json
+++ b/packages/firebase-module/package.json
@@ -28,7 +28,9 @@
     "docs": "cd docs && npm run dev"
   },
   "dependencies": {
-    "consola": "^2.15.3"
+    "consola": "^2.15.3",
+    "lodash": "^4.17.21",
+    "serialize-javascript": "^6.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.5",
@@ -47,14 +49,14 @@
     "cz-conventional-changelog": "latest",
     "eslint": "^8.0.1",
     "firebase": "^9.6.2",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.2",
     "jest": "^27.2.5",
     "nuxt": "^2.15.6",
+    "prettier": "^2.3.1",
     "proxy-mock-js": "^1.0.3",
-    "standard-version": "^9.3.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-prettier": "^4.0.0",
-    "prettier": "^2.3.1"
+    "standard-version": "^9.3.0"
   },
   "peerDependencies": {
     "firebase": "^9.6.2",


### PR DESCRIPTION
* Closes #443 

Merges the config found in `publicRuntimeConfig.firebase` with the module options, I don't think this works if you add the module to `buildModules`.

Adds functionality to compile/generate templates on startup, maybe there is a better way that doesn't require adding `lodash` and `serialize-javascript` as dependencies. The compilation also makes the assumption that the `nuxt` template global is always set to `$nuxt`, this can probably be cached/saved at build time for accuracy.

For dynamic configs the usage could be as follows
```js
publicRuntimeConfig: {
    firebase:
        process.env.CUSTOM_ENV_VARIABLE === 'production' ?
        // Production config
        {
            apiKey: '...',
            authDomain: '...',
            projectId: '...',
            storageBucket: '...',
            messagingSenderId: '...',
            appId: '...',
            measurementId: '...',
        } :
        // Development config
        {
            apiKey: '...',
            authDomain: '...',
            projectId: '...',
            storageBucket: '...',
            messagingSenderId: '...',
            appId: '...',
            measurementId: '...',
        },
}
```

To me this seems a bit easier or more flexible than the `customEnv` key and the nested environment configs. I suggest removing that approach if this feature gets added as the same can be achieved with runtime config and it could cause confusion/conflicts if nested configs are used in combination with runtime config.

My implementation _feels_ a bit hacky to me, so please let me know if there are any changes to be made! 😄

